### PR TITLE
Change system call to account for windows null redirect.

### DIFF
--- a/lib/pdf/info.rb
+++ b/lib/pdf/info.rb
@@ -18,7 +18,8 @@ module PDF
     end
 
     def command
-      output = `#{self.class.command_path} -enc UTF-8 -f 1 -l -1 "#{@pdf_path}" 2> /dev/null`
+      null_redirect = Gem.win_platform? ? 'nul' : '/dev/null'
+      output = `#{self.class.command_path} -enc UTF-8 -f 1 -l -1 "#{@pdf_path}" 2> #{null_redirect}`
       exit_code = $?
       case exit_code
       when 0 || nil


### PR DESCRIPTION
On windows, /dev/null doesn't exist and causes this command to fail.  2>nul works the same way on that platform.